### PR TITLE
Fixed bug where dismissing a presentedViewController would force RNSwipeViewController to unexpectedly revert to its centerViewController

### DIFF
--- a/RNSwipeViewController/RNSwipeViewController.h
+++ b/RNSwipeViewController/RNSwipeViewController.h
@@ -240,6 +240,14 @@ extern NSString * const RNSwipeViewControllerCenterDidAppear;
  */
 @property (assign, nonatomic) BOOL canTapOut;
 
+/** Disable/Enable swiping to all other controllers besides the current one.
+ 
+ @see canShowLeft
+ @see canShowRight
+ @see canShowBottom
+ */
+@property (assign, nonatomic) BOOL swipingDisabled;
+
 ///---------------------------------------------------------------------------------------
 /// @name Controller Delegates
 ///---------------------------------------------------------------------------------------

--- a/RNSwipeViewController/RNSwipeViewController.m
+++ b/RNSwipeViewController/RNSwipeViewController.m
@@ -176,8 +176,10 @@ static CGFloat kRNSwipeDefaultDuration = 0.3f;
 }
 
 - (void)viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
-    [self _layoutContainersAnimated:NO duration:0.f];
+    if (! self.visibleController.presentedViewController.isBeingDismissed) {
+        [super viewWillAppear:animated];
+        [self _layoutContainersAnimated:NO duration:0.f];
+    }
 }
 
 - (void)viewDidLayoutSubviews {

--- a/RNSwipeViewController/RNSwipeViewController.m
+++ b/RNSwipeViewController/RNSwipeViewController.m
@@ -391,6 +391,32 @@ static CGFloat kRNSwipeDefaultDuration = 0.3f;
     }
 }
 
+- (void)setSwipingDisabled:(BOOL)swipingDisabled {
+    
+    BOOL leftEnabled = ! swipingDisabled;
+    BOOL rightEnabled = ! swipingDisabled;
+    BOOL bottomEnabled = ! swipingDisabled;
+    
+    switch (self.visibleState) {
+        case RNSwipeVisibleLeft:
+            leftEnabled = YES;
+            break;
+        case RNSwipeVisibleRight:
+            rightEnabled = YES;
+            break;
+        case RNSwipeVisibleBottom:
+            bottomEnabled = YES;
+            break;
+        case RNSwipeVisibleCenter:
+            break;
+    }
+    self.canShowLeft = leftEnabled;
+    self.canShowRight = rightEnabled;
+    self.canShowBottom = bottomEnabled;
+    
+    _swipingDisabled = swipingDisabled;
+}
+
 #pragma mark - Getters
 
 - (UIViewController*)visibleController {


### PR DESCRIPTION
Ran into an issue where, after running presentViewController and subsequently dismissViewControlller from RNSwipeViewController's rightViewController, the RNSwipeViewController would force itself back to displaying centerViewController instead of sticking with the rightViewController. RNSwipeViewController will now suppress its viewWillAppear method if a presentedViewController is in the process of being dismissed. 
